### PR TITLE
9-create-video-player-view

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/iptriana/rickymortywiki/ui/core/components/VideoPlayer.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/iptriana/rickymortywiki/ui/core/components/VideoPlayer.android.kt
@@ -1,0 +1,21 @@
+package com.iptriana.rickymortywiki.ui.core.components
+
+import android.widget.MediaController
+import android.widget.VideoView
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+
+@Composable
+actual fun VideoPlayer(modifier: Modifier, url: String) {
+    AndroidView(modifier = modifier, factory = { context ->
+        val videoView = VideoView(context)
+        videoView.apply {
+            setVideoPath(url)
+            setMediaController(MediaController(context).apply {
+                setAnchorView(videoView)
+            })
+            start()
+        }
+    })
+}

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/data/RepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/data/RepositoryImpl.kt
@@ -6,13 +6,18 @@ import app.cash.paging.PagingData
 import com.iptriana.rickymortywiki.data.database.RickyMortyDatabase
 import com.iptriana.rickymortywiki.data.remote.ApiService
 import com.iptriana.rickymortywiki.data.remote.paging.CharacterPagingSource
+import com.iptriana.rickymortywiki.data.remote.paging.EpisodesPagingSource
 import com.iptriana.rickymortywiki.domain.Repository
 import com.iptriana.rickymortywiki.domain.model.CharacterModel
 import com.iptriana.rickymortywiki.domain.model.CharacterOfTheDayModel
+import com.iptriana.rickymortywiki.domain.model.EpisodeModel
 import kotlinx.coroutines.flow.Flow
 
 class RepositoryImpl(
-    private val api: ApiService, private val characterPagingSource: CharacterPagingSource, private val database: RickyMortyDatabase
+    private val api: ApiService,
+    private val characterPagingSource: CharacterPagingSource,
+    private val episodesPagingSource: EpisodesPagingSource,
+    private val database: RickyMortyDatabase
 ) : Repository {
 
     companion object {
@@ -26,6 +31,10 @@ class RepositoryImpl(
     override fun getAllCharacters(): Flow<PagingData<CharacterModel>> =
         Pager(config = PagingConfig(pageSize = MAX_ITEMS, prefetchDistance = PREFETCH_DISTANCE),
             pagingSourceFactory = { characterPagingSource }).flow
+
+    override fun getAllEpisodes(): Flow<androidx.paging.PagingData<EpisodeModel>> =
+        Pager(config = PagingConfig(pageSize = MAX_ITEMS, prefetchDistance = PREFETCH_DISTANCE),
+            pagingSourceFactory = { episodesPagingSource }).flow
 
     override suspend fun getCharacterDB(): CharacterOfTheDayModel? =
         database.getPreferencesDao().getCharacterOfTheDay()?.toDomain()

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/data/RepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/data/RepositoryImpl.kt
@@ -4,7 +4,6 @@ import androidx.paging.PagingConfig
 import app.cash.paging.Pager
 import app.cash.paging.PagingData
 import com.iptriana.rickymortywiki.data.database.RickyMortyDatabase
-import com.iptriana.rickymortywiki.data.database.entity.CharacterOfTheDayEntity
 import com.iptriana.rickymortywiki.data.remote.ApiService
 import com.iptriana.rickymortywiki.data.remote.paging.CharacterPagingSource
 import com.iptriana.rickymortywiki.domain.Repository

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/data/remote/ApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/data/remote/ApiService.kt
@@ -16,7 +16,7 @@ class ApiService(private val client: HttpClient) {
         parameter("page", page)
     }.body()
 
-    suspend fun getAllEpisodes(page: Int): EpisodesWrapperResponse = client.get("api/episode/"){
+    suspend fun getAllEpisodes(page: Int): EpisodesWrapperResponse = client.get("api/episode"){
         parameter("page", page)
     }.body()
 }

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/data/remote/ApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/data/remote/ApiService.kt
@@ -2,6 +2,7 @@ package com.iptriana.rickymortywiki.data.remote
 
 import com.iptriana.rickymortywiki.data.remote.response.CharacterResponse
 import com.iptriana.rickymortywiki.data.remote.response.CharacterWrapperResponse
+import com.iptriana.rickymortywiki.data.remote.response.EpisodesWrapperResponse
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
@@ -12,6 +13,10 @@ class ApiService(private val client: HttpClient) {
         client.get("api/character/$id").body()
 
     suspend fun getCharacters(page: Int): CharacterWrapperResponse = client.get("api/character/") {
+        parameter("page", page)
+    }.body()
+
+    suspend fun getAllEpisodes(page: Int): EpisodesWrapperResponse = client.get("api/episode/"){
         parameter("page", page)
     }.body()
 }

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/data/remote/paging/EpisodesPagingSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/data/remote/paging/EpisodesPagingSource.kt
@@ -4,7 +4,6 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.iptriana.rickymortywiki.data.remote.ApiService
 import com.iptriana.rickymortywiki.domain.model.EpisodeModel
-import io.ktor.utils.io.errors.IOException
 
 class EpisodesPagingSource(private val api: ApiService) : PagingSource<Int, EpisodeModel>() {
     override fun getRefreshKey(state: PagingState<Int, EpisodeModel>): Int? = state.anchorPosition
@@ -12,11 +11,11 @@ class EpisodesPagingSource(private val api: ApiService) : PagingSource<Int, Epis
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, EpisodeModel> = try {
         val page = params.key ?: 1
         val response = api.getAllEpisodes(page)
-        val episodes = response.results.map { it.toDomain() }
+        val episodes = response.results
         val prevKey = if (page > 1) page - 1 else null
-        val nextKey = if (episodes.isNotEmpty()) page + 1 else null
-        LoadResult.Page(data = episodes, prevKey = prevKey, nextKey = nextKey)
-    } catch (e: IOException) {
+        val nextKey = if (response.info.next != null) page + 1 else null
+        LoadResult.Page(data = episodes.map { it.toDomain() }, prevKey = prevKey, nextKey = nextKey)
+    } catch (e: Exception) {
         LoadResult.Error(e)
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/data/remote/paging/EpisodesPagingSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/data/remote/paging/EpisodesPagingSource.kt
@@ -1,0 +1,22 @@
+package com.iptriana.rickymortywiki.data.remote.paging
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.iptriana.rickymortywiki.data.remote.ApiService
+import com.iptriana.rickymortywiki.domain.model.EpisodeModel
+import io.ktor.utils.io.errors.IOException
+
+class EpisodesPagingSource(private val api: ApiService) : PagingSource<Int, EpisodeModel>() {
+    override fun getRefreshKey(state: PagingState<Int, EpisodeModel>): Int? = state.anchorPosition
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, EpisodeModel> = try {
+        val page = params.key ?: 1
+        val response = api.getAllEpisodes(page)
+        val episodes = response.results.map { it.toDomain() }
+        val prevKey = if (page > 1) page - 1 else null
+        val nextKey = if (episodes.isNotEmpty()) page + 1 else null
+        LoadResult.Page(data = episodes, prevKey = prevKey, nextKey = nextKey)
+    } catch (e: IOException) {
+        LoadResult.Error(e)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/data/remote/response/EpisodeResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/data/remote/response/EpisodeResponse.kt
@@ -8,23 +8,22 @@ import kotlinx.serialization.Serializable
 data class EpisodeResponse(
     val id: Int,
     val name: String,
-    val airDate: String,
     val episode: String,
     val characters: List<String>,
     val url: String,
-    val created: String
 ) {
-    fun toDomain(): EpisodeModel = EpisodeModel(
-        id = id,
-        name = name,
-        airDate = airDate,
-        episode = episode,
-        characters = characters.map { url -> url.substringAfter("/") },
-        url = url,
-        created = created,
-        season = getSeasonFromEpisodeCode(url),
-        videoUrl = getUrlFromSeason(getSeasonFromEpisodeCode(url))
-    )
+    fun toDomain(): EpisodeModel {
+        val season = getSeasonFromEpisodeCode(episode)
+        return EpisodeModel(
+            id = id,
+            name = name,
+            episode = episode,
+            characters = characters.map { url -> url.substringAfter("/") },
+            url = url,
+            season = season,
+            videoUrl = getUrlFromSeason(season)
+        )
+    }
 
     private fun getUrlFromSeason(season: SeasonEpisode): String = when (season) {
         SeasonEpisode.SEASON_1 -> "https://www.youtube.com/watch?v=8BEzj2kRjO8&ab_channel=RottenTomatoesTV"
@@ -38,13 +37,13 @@ data class EpisodeResponse(
     }
 
     private fun getSeasonFromEpisodeCode(episode: String): SeasonEpisode = when {
-        episode.contains("S01") -> SeasonEpisode.SEASON_1
-        episode.contains("S02") -> SeasonEpisode.SEASON_2
-        episode.contains("S03") -> SeasonEpisode.SEASON_3
-        episode.contains("S04") -> SeasonEpisode.SEASON_4
-        episode.contains("S05") -> SeasonEpisode.SEASON_5
-        episode.contains("S06") -> SeasonEpisode.SEASON_6
-        episode.contains("S07") -> SeasonEpisode.SEASON_7
+        episode.startsWith("S01") -> SeasonEpisode.SEASON_1
+        episode.startsWith("S02") -> SeasonEpisode.SEASON_2
+        episode.startsWith("S03") -> SeasonEpisode.SEASON_3
+        episode.startsWith("S04") -> SeasonEpisode.SEASON_4
+        episode.startsWith("S05") -> SeasonEpisode.SEASON_5
+        episode.startsWith("S06") -> SeasonEpisode.SEASON_6
+        episode.startsWith("S07") -> SeasonEpisode.SEASON_7
         else -> SeasonEpisode.UNKNOWN
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/data/remote/response/EpisodeResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/data/remote/response/EpisodeResponse.kt
@@ -1,0 +1,49 @@
+package com.iptriana.rickymortywiki.data.remote.response
+
+import com.iptriana.rickymortywiki.domain.model.EpisodeModel
+import com.iptriana.rickymortywiki.domain.model.SeasonEpisode
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EpisodeResponse(
+    val id: Int,
+    val name: String,
+    val airDate: String,
+    val episode: String,
+    val characters: List<String>,
+    val url: String,
+    val created: String
+) {
+    fun toDomain(): EpisodeModel = EpisodeModel(
+        id = id,
+        name = name,
+        airDate = airDate,
+        episode = episode,
+        characters = characters.map { url -> url.substringAfter("/") },
+        url = url,
+        created = created,
+        season =
+    )
+
+    private fun getUrlFromSeason(season: SeasonEpisode): String = when (season) {
+        SeasonEpisode.SEASON_1 -> "https://www.youtube.com/watch?v=8BEzj2kRjO8&ab_channel=RottenTomatoesTV"
+        SeasonEpisode.SEASON_2 -> "https://www.youtube.com/watch?v=SXwf_9xJu5c&ab_channel=Yusuto"
+        SeasonEpisode.SEASON_3 -> "https://www.youtube.com/watch?v=Bmg2vXOQ3kM&ab_channel=SeriesTrailerMP"
+        SeasonEpisode.SEASON_4 -> "https://www.youtube.com/watch?v=bLI2-v264No&ab_channel=RottenTomatoesTV"
+        SeasonEpisode.SEASON_5 -> "https://www.youtube.com/watch?v=yC1UxW8vcDo&ab_channel=RottenTomatoesTV"
+        SeasonEpisode.SEASON_6 -> "https://www.youtube.com/watch?v=jerFRSQW9g8&ab_channel=RottenTomatoesTV"
+        SeasonEpisode.SEASON_7 -> "https://www.youtube.com/watch?v=PkZtVBNkmso&ab_channel=RottenTomatoesTV"
+        else -> "https://www.youtube.com/watch?v=PkZtVBNkmso&ab_channel=RottenTomatoesTV"
+    }
+
+    private fun getSeasonFromEpisodeCode(episode: String): SeasonEpisode = when {
+        episode.contains("S01") -> SeasonEpisode.SEASON_1
+        episode.contains("S02") -> SeasonEpisode.SEASON_2
+        episode.contains("S03") -> SeasonEpisode.SEASON_3
+        episode.contains("S04") -> SeasonEpisode.SEASON_4
+        episode.contains("S05") -> SeasonEpisode.SEASON_5
+        episode.contains("S06") -> SeasonEpisode.SEASON_6
+        episode.contains("S07") -> SeasonEpisode.SEASON_7
+        else -> SeasonEpisode.UNKNOWN
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/data/remote/response/EpisodeResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/data/remote/response/EpisodeResponse.kt
@@ -22,7 +22,8 @@ data class EpisodeResponse(
         characters = characters.map { url -> url.substringAfter("/") },
         url = url,
         created = created,
-        season =
+        season = getSeasonFromEpisodeCode(url),
+        videoUrl = getUrlFromSeason(getSeasonFromEpisodeCode(url))
     )
 
     private fun getUrlFromSeason(season: SeasonEpisode): String = when (season) {

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/data/remote/response/EpisodeResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/data/remote/response/EpisodeResponse.kt
@@ -26,14 +26,14 @@ data class EpisodeResponse(
     }
 
     private fun getUrlFromSeason(season: SeasonEpisode): String = when (season) {
-        SeasonEpisode.SEASON_1 -> "https://www.youtube.com/watch?v=8BEzj2kRjO8&ab_channel=RottenTomatoesTV"
-        SeasonEpisode.SEASON_2 -> "https://www.youtube.com/watch?v=SXwf_9xJu5c&ab_channel=Yusuto"
-        SeasonEpisode.SEASON_3 -> "https://www.youtube.com/watch?v=Bmg2vXOQ3kM&ab_channel=SeriesTrailerMP"
-        SeasonEpisode.SEASON_4 -> "https://www.youtube.com/watch?v=bLI2-v264No&ab_channel=RottenTomatoesTV"
-        SeasonEpisode.SEASON_5 -> "https://www.youtube.com/watch?v=yC1UxW8vcDo&ab_channel=RottenTomatoesTV"
-        SeasonEpisode.SEASON_6 -> "https://www.youtube.com/watch?v=jerFRSQW9g8&ab_channel=RottenTomatoesTV"
-        SeasonEpisode.SEASON_7 -> "https://www.youtube.com/watch?v=PkZtVBNkmso&ab_channel=RottenTomatoesTV"
-        else -> "https://www.youtube.com/watch?v=PkZtVBNkmso&ab_channel=RottenTomatoesTV"
+        SeasonEpisode.SEASON_1 -> "https://firebasestorage.googleapis.com/v0/b/rickymortykmp.firebasestorage.app/o/videoplayback.mp4?alt=media&token=3e4edd7e-19eb-4616-9569-f229584c713b"
+        SeasonEpisode.SEASON_2 -> "https://firebasestorage.googleapis.com/v0/b/rickymortykmp.firebasestorage.app/o/videoplayback.mp4?alt=media&token=3e4edd7e-19eb-4616-9569-f229584c713b"
+        SeasonEpisode.SEASON_3 -> "https://firebasestorage.googleapis.com/v0/b/rickymortykmp.firebasestorage.app/o/videoplayback.mp4?alt=media&token=3e4edd7e-19eb-4616-9569-f229584c713b"
+        SeasonEpisode.SEASON_4 -> "https://firebasestorage.googleapis.com/v0/b/rickymortykmp.firebasestorage.app/o/videoplayback.mp4?alt=media&token=3e4edd7e-19eb-4616-9569-f229584c713b"
+        SeasonEpisode.SEASON_5 -> "https://firebasestorage.googleapis.com/v0/b/rickymortykmp.firebasestorage.app/o/videoplayback.mp4?alt=media&token=3e4edd7e-19eb-4616-9569-f229584c713b"
+        SeasonEpisode.SEASON_6 -> "https://firebasestorage.googleapis.com/v0/b/rickymortykmp.firebasestorage.app/o/videoplayback.mp4?alt=media&token=3e4edd7e-19eb-4616-9569-f229584c713b"
+        SeasonEpisode.SEASON_7 -> "https://firebasestorage.googleapis.com/v0/b/rickymortykmp.firebasestorage.app/o/videoplayback.mp4?alt=media&token=3e4edd7e-19eb-4616-9569-f229584c713b"
+        else -> "https://firebasestorage.googleapis.com/v0/b/rickymortykmp.firebasestorage.app/o/videoplayback.mp4?alt=media&token=3e4edd7e-19eb-4616-9569-f229584c713b"
     }
 
     private fun getSeasonFromEpisodeCode(episode: String): SeasonEpisode = when {

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/data/remote/response/EpisodesWrapperResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/data/remote/response/EpisodesWrapperResponse.kt
@@ -1,0 +1,9 @@
+package com.iptriana.rickymortywiki.data.remote.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EpisodesWrapperResponse (
+    val info: InfoResponse,
+    val results: List<EpisodeResponse>
+)

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/di/DataModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/di/DataModule.kt
@@ -3,6 +3,7 @@ package com.iptriana.rickymortywiki.di
 import com.iptriana.rickymortywiki.data.RepositoryImpl
 import com.iptriana.rickymortywiki.data.remote.ApiService
 import com.iptriana.rickymortywiki.data.remote.paging.CharacterPagingSource
+import com.iptriana.rickymortywiki.data.remote.paging.EpisodesPagingSource
 import com.iptriana.rickymortywiki.domain.Repository
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.DefaultRequest
@@ -30,6 +31,7 @@ val dataModule = module {
         }
     }
     factoryOf(::ApiService)
-    factory<Repository> { RepositoryImpl(get(), get(), get()) }
+    factory<Repository> { RepositoryImpl(get(), get(), get(), get()) }
     factoryOf(::CharacterPagingSource)
+    factoryOf(::EpisodesPagingSource)
 }

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/domain/Repository.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/domain/Repository.kt
@@ -3,12 +3,15 @@ package com.iptriana.rickymortywiki.domain
 import androidx.paging.PagingData
 import com.iptriana.rickymortywiki.domain.model.CharacterModel
 import com.iptriana.rickymortywiki.domain.model.CharacterOfTheDayModel
+import com.iptriana.rickymortywiki.domain.model.EpisodeModel
 import kotlinx.coroutines.flow.Flow
 
 
 interface Repository {
     suspend fun getSingleCharacter(id: String): CharacterModel
     fun getAllCharacters(): Flow<PagingData<CharacterModel>>
+    fun getAllEpisodes(): Flow<PagingData<EpisodeModel>>
     suspend fun getCharacterDB(): CharacterOfTheDayModel?
     suspend fun saveCharacterOfTheDay(character: CharacterOfTheDayModel)
+
 }

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/domain/model/EpisodeModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/domain/model/EpisodeModel.kt
@@ -3,11 +3,9 @@ package com.iptriana.rickymortywiki.domain.model
 data class EpisodeModel(
     val id: Int,
     val name: String,
-    val airDate: String,
     val episode: String,
     val characters: List<String>,
     val url: String,
-    val created: String,
     val videoUrl: String,
     val season: SeasonEpisode
 )

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/domain/model/EpisodeModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/domain/model/EpisodeModel.kt
@@ -1,0 +1,24 @@
+package com.iptriana.rickymortywiki.domain.model
+
+data class EpisodeModel(
+    val id: Int,
+    val name: String,
+    val airDate: String,
+    val episode: String,
+    val characters: List<String>,
+    val url: String,
+    val created: String,
+    val videoUrl: String,
+    val season: SeasonEpisode
+)
+
+enum class SeasonEpisode {
+    SEASON_1,
+    SEASON_2,
+    SEASON_3,
+    SEASON_4,
+    SEASON_5,
+    SEASON_6,
+    SEASON_7,
+    UNKNOWN
+}

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/ui/core/components/PaggingLoadingState.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/ui/core/components/PaggingLoadingState.kt
@@ -1,0 +1,15 @@
+package com.iptriana.rickymortywiki.ui.core.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun PagingLoadingState(modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/ui/core/components/PagingWrapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/ui/core/components/PagingWrapper.kt
@@ -1,0 +1,82 @@
+package com.iptriana.rickymortywiki.ui.core.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.paging.LoadState
+import app.cash.paging.compose.LazyPagingItems
+
+enum class PagingType {
+    ROW,
+    COLUMN,
+    VERTICAL_GRID
+}
+
+@Composable
+fun <T : Any> PagingWrapper(
+    pagingItems: LazyPagingItems<T>,
+    initialView: @Composable () -> Unit = {},
+    emptyView: @Composable () -> Unit = {},
+    extraItemsView: @Composable () -> Unit = {},
+    itemView: @Composable (T) -> Unit,
+    pagingType: PagingType
+){
+    when {
+        pagingItems.loadState.refresh is LoadState.Loading && pagingItems.itemCount == 0 -> {
+            // Initial loading
+            initialView()
+        }
+        pagingItems.loadState.refresh is LoadState.NotLoading && pagingItems.itemCount == 0 -> {
+            // No data
+            emptyView()
+        }
+        else -> {
+            // Content
+            when(pagingType){
+                PagingType.ROW -> {
+                    LazyRow {
+                        items(pagingItems.itemCount) { index ->
+                            pagingItems[index]?.let { item ->
+                                itemView(item)
+                            }
+                        }
+                    }
+                }
+                PagingType.VERTICAL_GRID -> {
+                    LazyVerticalGrid(
+                        modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+                        columns = GridCells.Fixed(2),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                    ) {
+                        items(pagingItems.itemCount) { index ->
+                            pagingItems[index]?.let { item ->
+                                itemView(item)
+                            }
+                        }
+                    }
+                }
+                PagingType.COLUMN -> {
+                    LazyColumn {
+                        items(pagingItems.itemCount) { index ->
+                            pagingItems[index]?.let { item ->
+                                itemView(item)
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (pagingItems.loadState.append is LoadState.Loading) {
+                extraItemsView()
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/ui/core/components/VideoPlayer.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/ui/core/components/VideoPlayer.kt
@@ -1,0 +1,7 @@
+package com.iptriana.rickymortywiki.ui.core.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+expect fun VideoPlayer(modifier: Modifier, url: String)

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/ui/home/tabs/episodes/EpisodesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/ui/home/tabs/episodes/EpisodesScreen.kt
@@ -1,17 +1,77 @@
 package com.iptriana.rickymortywiki.ui.home.tabs.episodes
 
-import androidx.compose.foundation.background
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import app.cash.paging.compose.collectAsLazyPagingItems
+import com.iptriana.rickymortywiki.domain.model.EpisodeModel
+import com.iptriana.rickymortywiki.domain.model.SeasonEpisode
+import com.iptriana.rickymortywiki.ui.core.components.PagingLoadingState
+import com.iptriana.rickymortywiki.ui.core.components.PagingType
+import com.iptriana.rickymortywiki.ui.core.components.PagingWrapper
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.annotation.KoinExperimentalAPI
+import rickymortywiki.composeapp.generated.resources.Res
+import rickymortywiki.composeapp.generated.resources.season1
+import rickymortywiki.composeapp.generated.resources.season2
+import rickymortywiki.composeapp.generated.resources.season3
+import rickymortywiki.composeapp.generated.resources.season4
+import rickymortywiki.composeapp.generated.resources.season5
+import rickymortywiki.composeapp.generated.resources.season6
+import rickymortywiki.composeapp.generated.resources.season7
 
 @OptIn(KoinExperimentalAPI::class)
 @Composable
 fun EpisodesScreen() {
     val episodesViewModel = koinViewModel<EpisodesViewModel>()
-    Box(Modifier.fillMaxSize().background(color = Color.Yellow))
+
+    val episodesState by episodesViewModel.state.collectAsState()
+    val episodes = episodesState.episodes.collectAsLazyPagingItems()
+    Box(Modifier.fillMaxSize()) {
+        PagingWrapper(
+            pagingType = PagingType.ROW,
+            pagingItems = episodes,
+            itemView = { EpisodeItemList(episode = it) },
+            emptyView = {},
+            initialView = { PagingLoadingState() }
+        )
+    }
+}
+
+@Composable
+fun EpisodeItemList(episode: EpisodeModel) {
+    Column(modifier = Modifier.width(120.dp).padding(horizontal = 8.dp).clickable { }) {
+        Image(
+            modifier = Modifier.height(200.dp).fillMaxWidth(),
+            contentDescription = null,
+            contentScale = ContentScale.Inside,
+            painter = painterResource(getSeasonImage(episode.season))
+        )
+    }
+}
+
+private fun getSeasonImage(season: SeasonEpisode): DrawableResource = when (season) {
+    SeasonEpisode.SEASON_1 -> Res.drawable.season1
+    SeasonEpisode.SEASON_2 -> Res.drawable.season2
+    SeasonEpisode.SEASON_3 -> Res.drawable.season3
+    SeasonEpisode.SEASON_4 -> Res.drawable.season4
+    SeasonEpisode.SEASON_5 -> Res.drawable.season5
+    SeasonEpisode.SEASON_6 -> Res.drawable.season6
+    SeasonEpisode.SEASON_7 -> Res.drawable.season7
+    SeasonEpisode.UNKNOWN -> Res.drawable.season1
 }

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/ui/home/tabs/episodes/EpisodesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/ui/home/tabs/episodes/EpisodesScreen.kt
@@ -1,18 +1,28 @@
 package com.iptriana.rickymortywiki.ui.home.tabs.episodes
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
@@ -22,11 +32,13 @@ import com.iptriana.rickymortywiki.domain.model.SeasonEpisode
 import com.iptriana.rickymortywiki.ui.core.components.PagingLoadingState
 import com.iptriana.rickymortywiki.ui.core.components.PagingType
 import com.iptriana.rickymortywiki.ui.core.components.PagingWrapper
+import com.iptriana.rickymortywiki.ui.core.components.VideoPlayer
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.annotation.KoinExperimentalAPI
 import rickymortywiki.composeapp.generated.resources.Res
+import rickymortywiki.composeapp.generated.resources.portal
 import rickymortywiki.composeapp.generated.resources.season1
 import rickymortywiki.composeapp.generated.resources.season2
 import rickymortywiki.composeapp.generated.resources.season3
@@ -42,20 +54,49 @@ fun EpisodesScreen() {
 
     val episodesState by episodesViewModel.state.collectAsState()
     val episodes = episodesState.episodes.collectAsLazyPagingItems()
-    Box(Modifier.fillMaxSize()) {
+    Column(Modifier.fillMaxSize()) {
         PagingWrapper(
             pagingType = PagingType.ROW,
             pagingItems = episodes,
-            itemView = { EpisodeItemList(episode = it) },
+            itemView = { EpisodeItemList(episode = it) { url -> episodesViewModel.onPlaySelected(url) } },
             emptyView = {},
             initialView = { PagingLoadingState() }
         )
+
+        EpisodePlayer(episodesState.playVideo, episodesViewModel::onCloseVideo)
     }
 }
 
 @Composable
-fun EpisodeItemList(episode: EpisodeModel) {
-    Column(modifier = Modifier.width(120.dp).padding(horizontal = 8.dp).clickable { }) {
+fun EpisodePlayer(playVideo: String, onCloseVideo: () -> Unit) {
+    AnimatedVisibility (playVideo.isNotBlank()) {
+        ElevatedCard(
+            modifier = Modifier.fillMaxWidth().height(250.dp).padding(16.dp)
+                .border(3.dp, Color.Green, CardDefaults.elevatedShape)
+        ) {
+            Box(modifier = Modifier.background(Color.Black)) {
+                Box(modifier = Modifier.padding(16.dp), contentAlignment = Alignment.Center) {
+                    VideoPlayer(Modifier.fillMaxWidth().height(200.dp), playVideo)
+                }
+                Row {
+                    Spacer(modifier = Modifier.weight(1f))
+                    Image(
+                        modifier = Modifier.size(40.dp).padding(8.dp).clickable { onCloseVideo() },
+                        contentDescription = null,
+                        contentScale = ContentScale.Inside,
+                        painter = painterResource(Res.drawable.portal)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun EpisodeItemList(episode: EpisodeModel, onEpisodeSelected: (String) -> Unit = {}) {
+    Column(
+        modifier = Modifier.width(120.dp).padding(horizontal = 8.dp)
+            .clickable { onEpisodeSelected(episode.videoUrl) }) {
         Image(
             modifier = Modifier.height(200.dp).fillMaxWidth(),
             contentDescription = null,

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/ui/home/tabs/episodes/EpisodesState.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/ui/home/tabs/episodes/EpisodesState.kt
@@ -1,0 +1,8 @@
+package com.iptriana.rickymortywiki.ui.home.tabs.episodes
+
+import androidx.paging.PagingData
+import com.iptriana.rickymortywiki.domain.model.EpisodeModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+
+data class EpisodesState(val episodes: Flow<PagingData<EpisodeModel>> = emptyFlow())

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/ui/home/tabs/episodes/EpisodesState.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/ui/home/tabs/episodes/EpisodesState.kt
@@ -5,4 +5,7 @@ import com.iptriana.rickymortywiki.domain.model.EpisodeModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 
-data class EpisodesState(val episodes: Flow<PagingData<EpisodeModel>> = emptyFlow())
+data class EpisodesState(
+    val episodes: Flow<PagingData<EpisodeModel>> = emptyFlow(),
+    val playVideo: String = ""
+)

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/ui/home/tabs/episodes/EpisodesViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/ui/home/tabs/episodes/EpisodesViewModel.kt
@@ -1,7 +1,18 @@
 package com.iptriana.rickymortywiki.ui.home.tabs.episodes
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.paging.cachedIn
+import com.iptriana.rickymortywiki.domain.Repository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 
-class EpisodesViewModel: ViewModel() {
+class EpisodesViewModel(private val repository: Repository): ViewModel() {
+    private val _state: MutableStateFlow<EpisodesState> = MutableStateFlow(EpisodesState())
+    val state: StateFlow<EpisodesState> = _state
 
+    init {
+        _state.update { state -> state.copy(episodes = repository.getAllEpisodes().cachedIn(viewModelScope)) }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/ui/home/tabs/episodes/EpisodesViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/iptriana/rickymortywiki/ui/home/tabs/episodes/EpisodesViewModel.kt
@@ -9,10 +9,19 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 
 class EpisodesViewModel(private val repository: Repository): ViewModel() {
+
     private val _state: MutableStateFlow<EpisodesState> = MutableStateFlow(EpisodesState())
     val state: StateFlow<EpisodesState> = _state
 
     init {
         _state.update { state -> state.copy(episodes = repository.getAllEpisodes().cachedIn(viewModelScope)) }
+    }
+
+    fun onPlaySelected(url: String) {
+        _state.update { state -> state.copy(playVideo = url) }
+    }
+
+    fun onCloseVideo() {
+        _state.update { state -> state.copy(playVideo = "") }
     }
 }

--- a/composeApp/src/iosMain/kotlin/com/iptriana/rickymortywiki/ui/core/components/VideoPlayer.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/iptriana/rickymortywiki/ui/core/components/VideoPlayer.ios.kt
@@ -1,0 +1,33 @@
+package com.iptriana.rickymortywiki.ui.core.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.interop.UIKitView
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSURL
+import platform.Foundation.NSURLRequest
+import platform.UIKit.UIView
+import platform.UIKit.UIViewAutoresizingFlexibleHeight
+import platform.UIKit.UIViewAutoresizingFlexibleWidth
+import platform.WebKit.WKWebView
+
+@OptIn(ExperimentalForeignApi::class)
+@Composable
+actual fun VideoPlayer(modifier: Modifier, url: String) {
+    val webView = remember { WKWebView() }
+    UIKitView(modifier = modifier, factory = {
+        val container = UIView().apply {
+            autoresizingMask = UIViewAutoresizingFlexibleWidth or UIViewAutoresizingFlexibleHeight
+        }
+        webView.apply {
+            autoresizingMask = UIViewAutoresizingFlexibleWidth or UIViewAutoresizingFlexibleHeight
+            loadRequest(NSURLRequest(NSURL(string = url)))
+        }
+        container.addSubview(webView)
+        container
+    },
+        update = {
+            webView.subviews().firstOrNull { it is WKWebView }
+        })
+}


### PR DESCRIPTION
feat: Add visual feedback to the episode player

This change adds a green border to the episode player card when an episode is playing.
This provides visual feedback to the user, making it clear that an episode is currently active.

The border is implemented using the `border` modifier in Jetpack Compose. It is only applied when the `playVideo` state is not blank, indicating that an episode is being played.